### PR TITLE
Wireguard

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -124,6 +124,10 @@
                                         publickey ='5Ys1FvqsheP5rS759fLzjYiPekUpDZSAjwj6PauHNU4=',
                                         endpoint ='bonn4.kbu.freifunk.net:10020',
                                 },
+                                {
+                                        publickey ='NrUOlGg/67BGt83lo1dnkeQW8mSuAo7XKYFcnyFvT3M=',
+                                        endpoint ='bonn5.kbu.freifunk.net:10020',
+                                },
                         },
         },
 

--- a/site.mk
+++ b/site.mk
@@ -181,7 +181,7 @@ GLUON_tp-link-tl-wdr4900-v1_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKA
 #               to decide if a version is newer or not.
 
 #DEFAULT_GLUON_RELEASE := 0.6+mstr$(shell date '+%Y%m%d')
-DEFAULT_GLUON_RELEASE := v2018.2.2-Wireguard
+DEFAULT_GLUON_RELEASE := v2018.2.3-Wireguard
 
 
 ##      GLUON_RELEASE

--- a/site.mk
+++ b/site.mk
@@ -192,7 +192,7 @@ DEFAULT_GLUON_RELEASE := v2018.2.2-Wireguard
 #                       gluon-ff%site_code%-23.42+5-%router_model%.bin
 
 # Allow overriding the release number from the command line
-GLUON_RELEASE ?= v2018.2.2-Wireguard
+GLUON_RELEASE ?= v2018.2.3-Wireguard
 
 # Default priority for updates.
 GLUON_PRIORITY ?= 0


### PR DESCRIPTION
add wireguard endpoint bonn5.kbu.freifunk.net

change firmware filename to current gluon version v2018.2.3